### PR TITLE
Add balenaCloud Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Here are some of those repositories that will give you a head start in open sour
 - [Docusaurus](https://github.com/facebook/docusaurus)
 - [First Contributions](https://github.com/firstcontributions/first-contributions)
 - [Angular](https://github.com/angular/angular)
+- [balenaCloud Docs](https://github.com/balena-io/docs)
 
 ## 🏅 Open Source Programs
 


### PR DESCRIPTION
As per https://github.com/Sriparno08/Openpedia/issues/66

Added balenaCloud Docs github page to list

## Description

Added balenaCloud Docs github page to list in specified category

## Category (If Applicable)

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding category -->

- [ ] Introduction to Open Source
- [ ] Learn Git and GitHub
- [ ] Contributing to Open Source
- [x ] Beginner-Friendly Repositories
- [ ] Open Source Programs

## Related Issue

[<!-- Link the PR to the corresponding issue by replacing 'XX' with the issue number -->]

Fixes #66 

## Checklist

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding criteria -->

- [ x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x ] The name of the resource is correctly spelled (if applicable)
- [x ] The link to the resource is working (if applicable)
- [ x] The resource is added in the correct format (if applicable)

