### PR TITLE
 The diff is changing the resource type "YouTube Video" to "Video".

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ git commit -m "Add a/an <resource-type> from <publisher>"
 Resource Types:
 
 - Article
-- YouTube Video
+- Video
 
 If the resource belongs to any of these following categories:
 


### PR DESCRIPTION
## Description

<!-- Describe the changes made in the PR -->

## Category (If Applicable)

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding category -->

- [ ] Introduction to Open Source
- [ ] Learn Git and GitHub
- [ ] Contributing to Open Source
- [ ] Beginner-Friendly Repos
- [ ] Open Source Programs

## Related Issue

<!-- Link the PR to the corresponding issue by replacing 'XX' with the issue number -->

Fixes #80

## Checklist

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding criteria -->

- [x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x] The name of the resource is correctly spelled (if applicable)
- [x] The link to the resource is working (if applicable)
- [x] The resource is added in the correct format (if applicable)
