### PR TITLE
UI: Change Font Size of Copyright Text Updated

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -476,7 +476,7 @@ footer {
 footer .copyright {
   color: white;
   text-align: center;
-  font-size: 16px;
+  font-size: 14px;
 }
 
 footer .creator {

--- a/client/styles.css
+++ b/client/styles.css
@@ -476,6 +476,7 @@ footer {
 footer .copyright {
   color: white;
   text-align: center;
+  font-size: 16px;
 }
 
 footer .creator {


### PR DESCRIPTION
## Description

changed the font size of the landing page copyright text from 13px to 16px:

## Category

- [ ] Documentation
- [ ] Resource Addition
- [ ] Codebase
- [x] User Interface
- [ ] Feature Request

## Related Issue

Fixes #219 

## Checklist

- [x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x] The name of the resource is spelled correctly (if applicable)
- [x] The link to the resource is working (if applicable)
- [x] The resource is added in the correct format (if applicable)
- [x] I have tested changes on my local computer (if applicable)
