### PR TITLE
Removed the FAQ from introduction to Opensource page navbar

### DIFF
--- a/client/Introduction-opensource/index.html
+++ b/client/Introduction-opensource/index.html
@@ -29,7 +29,6 @@
         <ul class="links">
             <!-- <li class="item"><a class="link">Home</a></li> -->
             <li class="item"><a href="../index.html" class="link">Home</a></li>
-            <li class="item"><a href="../faq/index.html" class="link" target="_blank">FAQ</a></li>
             <li class="item">
                 <a href="https://github.com/Sriparno08/Openpedia" class="link">GitHub</a>
             </li>

--- a/client/index.html
+++ b/client/index.html
@@ -35,7 +35,6 @@
 
           <ul class="links">
             <li class="item"><a href="#about" class="link">About</a></li>
-            <li class="item"><a href="./faq/index.html" class="link" target="_blank">FAQ</a></li>
             <li class="item">
               <a href="https://github.com/Sriparno08/Openpedia" class="link">GitHub</a>
             </li>


### PR DESCRIPTION
## Description

I removed the FAQ from introduction to Opensource page navbar and made a contribution as a part of JWOC'24

## Category

- [ ] Documentation
- [ ] Resource Addition
- [x] Codebase
- [ ] User Interface
- [ ] Feature Request

## Related Issue

Fixes #307 

## Checklist

- [x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x] The name of the resource is spelled correctly (if applicable)
- [x] The link to the resource is working (if applicable)
- [x] The resource is added in the correct format (if applicable)
- [x] I have tested changes on my local computer (if applicable)
