### PR TITLE
Chore: Remove 'Home' from 'Introduction to Open Source' Page Navbar

### DIFF
--- a/client/Contributing to Opensource/index.html
+++ b/client/Contributing to Opensource/index.html
@@ -9,8 +9,6 @@
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="../styles.css">
-    <link rel="stylesheet" href="../src/theme/theme_switch.css">
     <link rel="shortcut icon" href="../assets/oLogo.svg" type="image/x-icon">
 </head>
 
@@ -19,13 +17,7 @@
         <div class="title-container">
             <p class="title"><a href="../index.html" class="link"><img src="../assets/oLogo.svg"
                         alt="Openpedia">PENPEDIA</a></p>
-            <div id="themeBody">
-                <!-- <img id="themeToggle" src="./src/theme/icon/sun.png" alt=""> -->
-                <button id="themeToggle">
-                    <i class="fas fa-sun"></i> <!-- Font Awesome sun icon -->
-                    <i class="fas fa-moon"></i> <!-- Font Awesome moon icon -->
-                </button>
-            </div>
+
             <div class=" hamburger">
                 <span class="bar"></span>
                 <span class="bar"></span>
@@ -36,7 +28,7 @@
         <ul class="links">
             <!-- <li class="item"><a class="link">Home</a></li> -->
             <li class="item"><a href="../index.html" class="link">Home</a></li>
-            
+            <li class="item"><a href="../faq/index.html" class="link" target="_blank">FAQ</a></li>
             <li class="item">
                 <a href="https://github.com/Sriparno08/Openpedia" class="link">GitHub</a>
             </li>
@@ -381,10 +373,10 @@
     </footer>
     <a href="#" class="to-top">
         <i class="fas fa-chevron-up"></i>
-    </a>
+      </a>
 
+    <script src="./app.js"></script>
     <script src="../app.js"></script>
-    <script src="../src/theme/theme_switch.js"></script>
 </body>
 
 </html>

--- a/client/Introduction-opensource/index.html
+++ b/client/Introduction-opensource/index.html
@@ -7,10 +7,8 @@
 
     <title>Openpedia: Introduction to Open-Source</title>
 
-    <link rel="stylesheet" href="../src/theme/theme_switch.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="../styles.css">
     <link rel="shortcut icon" href="../assets/oLogo.svg" type="image/x-icon">
 </head>
 
@@ -20,13 +18,7 @@
         <div class="title-container">
             <p class="title"><a href="../index.html" class="link"><img src="../assets/oLogo.svg"
                         alt="Openpedia">PENPEDIA</a></p>
-            <div id="themeBody">
-                <!-- <img id="themeToggle" src="./src/theme/icon/sun.png" alt=""> -->
-                <button id="themeToggle">
-                    <i class="fas fa-sun"></i> <!-- Font Awesome sun icon -->
-                    <i class="fas fa-moon"></i> <!-- Font Awesome moon icon -->
-                </button>
-            </div>
+
             <div class=" hamburger">
                 <span class="bar"></span>
                 <span class="bar"></span>
@@ -227,44 +219,48 @@
 
     <footer>
         <div class="contain">
-            <div class="row">
-                <div class="col">
-                    <a href="../index.html" class="link">Openpedia</a>
-                </div>
-                <div class="col">
-                    <h3 id="Support" style="font-size: 15px;">Support</h3>
-                    <p style="font-size: 14px;">Documentation</p>
-                </div>
-                <div class="col">
-                    <h3 id="Solutions" style="font-size: 15px;">Categories</h3>
-                    <p><a href="../git/index.html" class="footer-links">Learn Git &
-                            GitHub</a></p>
-                    <p><a href="https://openpedia.netlify.app/contributing-to-open-source"
-                            class="footer-links">Contributing to
-                            Open Source</a></p>
-                    <p><a href="../beginner-friendly-repo/index.html" class="footer-links">Beginner-Friendly
-                            Repos</a></p>
-                    <p><a href="../opensource_programs/index.html" class="footer-links">Open Source
-                            Programs</a></p>
-                </div>
+          <div class="row">
+            <div class="col">
+              <a href="../index.html" class="link">Openpedia</a>
             </div>
+            <div class="col">
+              <h3 id="Support" style="font-size: 15px;">Support</h3>
+              <p style="font-size: 14px;">Documentation</p>
+            </div>
+            <div class="col">
+              <h3 id="Solutions" style="font-size: 15px;">Categories</h3>
+              <p><a href="../git/index.html"
+                class="footer-links">Learn Git &
+                  GitHub</a></p>
+              <p><a href="https://openpedia.netlify.app/contributing-to-open-source"
+                class="footer-links">Contributing to
+                  Open Source</a></p>
+              <p><a href="../beginner-friendly-repo/index.html"
+                class="footer-links">Beginner-Friendly
+                  Repos</a></p>
+              <p><a href="../opensource_programs/index.html"
+                class="footer-links">Open Source
+                  Programs</a></p>
+            </div>
+          </div>
 
-            <div class="end">
-                <span class="copyright">&copy; 2024 Openpedia</span>
-                <span class="creator">Developed By Sriparno Roy & Open Source Community</span>
-                <span class="social media" id="socialicons">
-                    <i><a href="https://www.linkedin.com/in/sriparnoroy" class="fa-brands fa-linkedin-in"></a></i>
-                    <i><a href="https://twitter.com/Sriparno08" class="fa-brands fa-x-twitter"></a></i>
-                    <i><a href="https://github.com/Sriparno08" class="fa-brands fa-github"></a></i>
-                </span>
-            </div>
+          <div class="end">
+            <span class="copyright">&copy; 2024 Openpedia</span>
+            <span class="creator">Developed By Sriparno Roy & Open Source Community</span>
+            <span class="social media" id="socialicons">
+              <i ><a href="https://www.linkedin.com/in/sriparnoroy" class="fa-brands fa-linkedin-in"></a></i>
+              <i ><a href="https://twitter.com/Sriparno08"class="fa-brands fa-x-twitter"></a></i>
+              <i ><a href="https://github.com/Sriparno08"class="fa-brands fa-github"></a></i>
+            </span>
+          </div>
         </div>
-    </footer>
-    <a href="#" class="to-top">
+      </footer>
+      <a href="#" class="to-top">
         <i class="fas fa-chevron-up"></i>
-    </a>
+      </a>
+
+    <script src="./app.js"></script>
     <script src="../app.js"></script>
-    <script src="../src/theme/theme_switch.js"></script>
 </body>
 
 </html>

--- a/client/beginner-friendly-repo/index.html
+++ b/client/beginner-friendly-repo/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,25 +9,15 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="../styles.css">
-    <link rel="stylesheet" href="../src/theme/theme_switch.css">
     <link rel="shortcut icon" href="../assets/oLogo.svg" type="image/x-icon">
 </head>
-
 <body>
     <main class="container">
         <header>
             <div class="title-container">
                 <p class="title"><a href="../index.html" class="link"><img src="../assets/oLogo.svg"
-                            alt="Openpedia">PENPEDIA</a></p>
+                    alt="Openpedia">PENPEDIA</a></p>
 
-                <div id="themeBody">
-                    <!-- <img id="themeToggle" src="./src/theme/icon/sun.png" alt=""> -->
-                    <button id="themeToggle">
-                        <i class="fas fa-sun"></i> <!-- Font Awesome sun icon -->
-                        <i class="fas fa-moon"></i> <!-- Font Awesome moon icon -->
-                    </button>
-                </div>
                 <div class="hamburger" onclick="toggleMenu()">
                     <span class="bar"></span>
                     <span class="bar"></span>
@@ -46,57 +35,50 @@
         <section>
             <img src="cloud-based-school.png" alt="loading" class="image">
             <h1>Ready to embark on your open source adventure?</h1>
-            <h1> <br></h1>
-            <p id="top">These repos offer a curated selection of beginner-friendly issues that will turn you into a
-                skilled open source contributor:</p>
-            <h1> <br></h1>
+            <h1>   <br></h1>
+            <p id="top">These repos offer a curated selection of beginner-friendly issues that will turn you into a skilled open source contributor:</p>
+            <h1>   <br></h1>
             <h2 id="web">Web Development Documentation Repos</h2>
             <div class="card">
                 <h3>MDN Web Docs</h3>
-                <p>MDN Web Docs is an open-source, collaborative project that documents web technologies including CSS,
-                    HTML,
-                    JavaScript, and Web APIs. Alongside detailed reference documentation, we provide extensive learning
+                <p>MDN Web Docs is an open-source, collaborative project that documents web technologies including CSS, HTML, 
+                    JavaScript, and Web APIs. Alongside detailed reference documentation, we provide extensive learning 
                     resources for students and beginners getting started with web development... <a
                         href="https://github.com/mdn/content">Read More</a>
                 </p>
             </div>
             <div class="card">
                 <h3>freeCodeCamp</h3>
-                <p>freeCodeCamp.org is a friendly community where you can learn to code for free. It is run by a
-                    donor-supported
-                    501(c)(3) charity to help millions of busy adults transition into tech. Our community has already
-                    helped more
-                    than 40,000 people get their first developer job... <a
-                        href="https://github.com/freeCodeCamp/freeCodeCamp">Read More</a></p>
+                <p>freeCodeCamp.org is a friendly community where you can learn to code for free. It is run by a donor-supported 
+                    501(c)(3) charity to help millions of busy adults transition into tech. Our community has already helped more 
+                    than 40,000 people get their first developer job... <a href="https://github.com/freeCodeCamp/freeCodeCamp">Read More</a></p>
             </div>
             <div class="card">
                 <h3>Codecademy Docs</h3>
-                <p>Codecademy Docs is a collection of information for all things code...
+                <p>Codecademy Docs is a collection of information for all things code... 
                     <a href="https://github.com/Codecademy/docs">Read More</a>
                 </p>
             </div>
             <div class="card">
                 <h3>GitHub Docs</h3>
-                <p>This repository contains the documentation website code and Markdown source files for
-                    docs.github.com. GitHub's
-                    Docs team works on pre-production content in a private repo that regularly syncs with this public
-                    repo... <a href="https://github.com/github/docs">Read More</a></p>
+                <p>This repository contains the documentation website code and Markdown source files for docs.github.com. GitHub's 
+                    Docs team works on pre-production content in a private repo that regularly syncs with this public repo... <a
+                        href="https://github.com/github/docs">Read More</a></p>
             </div>
             <div class="card">
                 <h3>Docusaurus</h3>
-                <p>Docusaurus is a project for building, deploying, and maintaining open source project websites
-                    easily... <a href="https://github.com/facebook/docusaurus">Read More</a></p>
+                <p>Docusaurus is a project for building, deploying, and maintaining open source project websites easily... <a
+                        href="https://github.com/facebook/docusaurus">Read More</a></p>
             </div>
             <div class="card">
                 <h3>First Contributions</h3>
-                <p>This repo aims to simplify and guide the way beginners make their first contribution. If you are
+                <p>This repo aims to simplify and guide the way beginners make their first contribution. If you are 
                     looking to make your first contribution, follow the steps below... <a
                         href="https://github.com/firstcontributions/first-contributions">Read More</a></p>
             </div>
             <div class="card">
                 <h3>balenaCloud Docs</h3>
-                <p>Documentation for the balenaCloud platform lives here. This repo intends to provide our public-facing
-                    documentation. To view the documentation
+                <p>Documentation for the balenaCloud platform lives here. This repo intends to provide our public-facing documentation. To view the documentation 
                     generated by this repo, one could either run locally or view the hosted version... <a
                         href="https://github.com/balena-io/docs">Read More</a></p>
             </div>
@@ -107,22 +89,22 @@
             </div>
             <div class="card">
                 <h3>Storybook</h3>
-                <p>Storybook is a frontend workshop for building UI components and pages in isolation.
+                <p>Storybook is a frontend workshop for building UI components and pages in isolation. 
                     Thousands of teams use it for UI development, testing, and documentation... <a
                         href="https://github.com/storybookjs/storybook">Read More</a></p>
             </div>
             <div class="card">
                 <h3>Prettier</h3>
-                <p>Prettier is an opinionated code formatter. It enforces a consistent style by parsing
-                    your code and re-printing it with its own rules that take the maximum line length into account,
-                    wrapping code when necessary... <a href="https://github.com/prettier/prettier">Read More</a></p>
+                <p>Prettier is an opinionated code formatter. It enforces a consistent style by parsing 
+                    your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary... <a
+                        href="https://github.com/prettier/prettier">Read More</a></p>
             </div>
             <div class="card" id="novu">
                 <h3>Novu</h3>
                 <p>The ultimate service for managing multi-channel notifications with a single API... <a
                         href="https://github.com/novuhq/novu">Read More</a></p>
             </div>
-
+    
             <h2>JavaScript Libraries & Frameworks</h2>
             <div class="card">
                 <h3>React</h3>
@@ -131,85 +113,84 @@
             </div>
             <div class="card">
                 <h3>React Native</h3>
-                <p>React Native brings React's declarative UI framework to iOS and Android.
+                <p>React Native brings React's declarative UI framework to iOS and Android. 
                     With React Native, you use native UI controls and have full access to the native platform... <a
                         href="https://github.com/facebook/react-native">Read More</a></p>
             </div>
             <div class="card">
                 <h3>Angular</h3>
                 <p>Angular is a development platform for building mobile and desktop web applications
-                    using TypeScript/JavaScript and other languages... <a href="https://github.com/angular/angular">Read
-                        More</a></p>
+                    using TypeScript/JavaScript and other languages... <a
+                        href="https://github.com/angular/angular">Read More</a></p>
             </div>
             <div class="card">
                 <h3>Bootstrap</h3>
-                <p>The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first projects
-                    on the web... <a href="https://github.com/twbs/bootstrap">Read More</a></p>
+                <p>The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web... <a
+                        href="https://github.com/twbs/bootstrap">Read More</a></p>
             </div>
             <div class="card" id="arrow">
                 <h3>Apache Arrow</h3>
-                <p>Apache Arrow is a development platform for in-memory analytics. It contains a set of technologies
-                    that enable
-                    big data systems to process and move data fast... <a href="https://github.com/apache/arrow">Read
-                        More</a></p>
+                <p>Apache Arrow is a development platform for in-memory analytics. It contains a set of technologies that enable 
+                    big data systems to process and move data fast... <a
+                        href="https://github.com/apache/arrow">Read More</a></p>
             </div>
-
+    
             <h2>Machine Learning & AI</h2>
             <div class="card" id="mind">
                 <h3>MindsDB</h3>
-                <p>MindsDB's AI SQL Server enables developers to build AI tools that need access to real-time data to
-                    perform their tasks... <a href="https://github.com/mindsdb/mindsdb">Read More</a></p>
+                <p>MindsDB's AI SQL Server enables developers to build AI tools that need access to real-time data to 
+                    perform their tasks... <a
+                        href="https://github.com/mindsdb/mindsdb">Read More</a></p>
             </div>
             <h2>Bioinformatics</h2>
             <div class="card" id="drop">
                 <h3>BioDrop</h3>
-                <p>A platform where people in tech can have a single hub to showcase their content in order to
-                    accelerate their
-                    career, whilst contributing to an Open Source project and being part of a community that has a say
-                    in where
-                    the project is going... <a href="https://github.com/EddieHubCommunity/BioDrop">Read More</a></p>
+                <p>A platform where people in tech can have a single hub to showcase their content in order to accelerate their 
+                    career, whilst contributing to an Open Source project and being part of a community that has a say in where 
+                    the project is going... <a
+                        href="https://github.com/EddieHubCommunity/BioDrop">Read More</a></p>
             </div>
         </section>
         <footer>
             <div class="contain">
-                <div class="row">
-                    <div class="col">
-                        <a href="../index.html" class="link">Openpedia</a>
-                    </div>
-                    <div class="col">
-                        <h3 id="Support" style="font-size: 15px;">Support</h3>
-                        <p style="font-size: 14px;">Documentation</p>
-                    </div>
-                    <div class="col">
-                        <h3 id="Solutions" style="font-size: 15px;">Categories</h3>
-                        <p><a href="../Introduction-opensource/index.html" class="footer-links">Introduction to Open
-                                Source</a></p>
-                        <p><a href="../git/index.html" class="footer-links">Learn Git & GitHub</a></p>
-                        <p><a href="https://openpedia.netlify.app/contributing-to-open-source"
-                                class="footer-links">Contributing to Open Source</a></p>
-                        <p><a href="../opensource_programs/index.html" class="footer-links">Open Source Programs</a></p>
-                    </div>
+              <div class="row">
+                <div class="col">
+                  <a href="../index.html" class="link">Openpedia</a>
                 </div>
-
-                <div class="end">
-                    <span class="copyright">&copy; 2024 Openpedia</span>
-                    <span class="creator">Developed By Sriparno Roy & Open Source Community</span>
-                    <span class="social media" id="socialicons">
-                        <i><a href="https://www.linkedin.com/in/sriparnoroy" class="fa-brands fa-linkedin-in"></a></i>
-                        <i><a href="https://twitter.com/Sriparno08" class="fa-brands fa-x-twitter"></a></i>
-                        <i><a href="https://github.com/Sriparno08" class="fa-brands fa-github"></a></i>
-                    </span>
+                <div class="col">
+                  <h3 id="Support" style="font-size: 15px;">Support</h3>
+                  <p style="font-size: 14px;">Documentation</p>
                 </div>
+                <div class="col">
+                  <h3 id="Solutions" style="font-size: 15px;">Categories</h3>
+                  <p><a href="../Introduction-opensource/index.html"
+                      class="footer-links">Introduction to Open Source</a></p>
+                  <p><a href="../git/index.html"
+                    class="footer-links">Learn Git & GitHub</a></p>
+                  <p><a href="https://openpedia.netlify.app/contributing-to-open-source"
+                    class="footer-links">Contributing to Open Source</a></p>
+                  <p><a href="../opensource_programs/index.html"
+                    class="footer-links">Open Source Programs</a></p>
+                </div>
+              </div>
+    
+              <div class="end">
+                <span class="copyright">&copy; 2024 Openpedia</span>
+                <span class="creator">Developed By Sriparno Roy & Open Source Community</span>
+                <span class="social media" id="socialicons">
+                  <i ><a href="https://www.linkedin.com/in/sriparnoroy" class="fa-brands fa-linkedin-in"></a></i>
+                  <i ><a href="https://twitter.com/Sriparno08"class="fa-brands fa-x-twitter"></a></i>
+                  <i ><a href="https://github.com/Sriparno08"class="fa-brands fa-github"></a></i>
+                </span>
+              </div>
             </div>
-        </footer>
+          </footer>
     </main>
     <a href="#" class="to-top">
         <i class="fas fa-chevron-up"></i>
-    </a>
+      </a>
     <script src="script.js"></script>
     <script src="../app.js"></script>
-    <script src="../src/theme/theme_switch.js"></script>
 
 </body>
-
 </html>

--- a/client/opensource_programs/index.html
+++ b/client/opensource_programs/index.html
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="../src/theme/theme_switch.css">
      <link rel="shortcut icon" href="../assets/oLogo.svg" type="image/x-icon">
 </head>
 
@@ -20,22 +19,13 @@
         <div class="title-container">
             <p class="title"><a href="../index.html" class="link"><img src="../assets/oLogo.svg"
                         alt="Openpedia">PENPEDIA</a></p>
+
+            <div class=" hamburger">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </div>
         </div>
-        <div class="elemContainer">
-            <div id="themeBody">
-              <!-- <img id="themeToggle" src="./src/theme/icon/sun.png" alt=""> -->
-              <button id="themeToggle">
-                <i class="fas fa-sun"></i> <!-- Font Awesome sun icon -->
-                <i class="fas fa-moon"></i> <!-- Font Awesome moon icon -->
-              </button>
-            </div>
-    
-            <div class="hamburger">
-              <span class="bar"></span>
-              <span class="bar"></span>
-              <span class="bar"></span>
-            </div>
-          </div>
 
         <ul class="links">
             <!-- <li class="item"><a class="link">Home</a></li> -->
@@ -206,7 +196,6 @@
     
 
     <script src="../app.js"></script>
-    <script src="../src/theme/theme_switch.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Description

I removed the home button from introduction to open source page as a contribution under JWOC'24

## Category

- [ ] Documentation
- [ ] Resource Addition
- [x] Codebase
- [ ] User Interface
- [ ] Feature Request

## Related Issue

Fixes #313

## Checklist

- [x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x] The name of the resource is spelled correctly (if applicable)
- [x] The link to the resource is working (if applicable)
- [x] The resource is added in the correct format (if applicable)
- [x] I have tested changes on my local computer (if applicable)
