### PR TITLE
Removed about button from Learn Git & Github page

### DIFF
--- a/client/Introduction-opensource/index.html
+++ b/client/Introduction-opensource/index.html
@@ -35,8 +35,6 @@
         </div>
 
         <ul class="links">
-            <!-- <li class="item"><a class="link">Home</a></li> -->
-            <li class="item"><a href="../index.html" class="link">Home</a></li>
             <li class="item">
                 <a href="https://github.com/Sriparno08/Openpedia" class="link">GitHub</a>
             </li>

--- a/client/git/index.html
+++ b/client/git/index.html
@@ -37,7 +37,6 @@
         </div>
 
         <ul class="links">
-          <li class="item"><a href="#about" class="link">About</a></li>
           <li class="item">
             <a href="https://github.com/Sriparno08/Openpedia" class="link">GitHub</a>
           </li>


### PR DESCRIPTION
## Description

I removed the about button from learn Git & Github page as a contribution under JWOC'24

## Category

- [ ] Documentation
- [ ] Resource Addition
- [x] Codebase
- [ ] User Interface
- [ ] Feature Request

## Related Issue

Fixes #314 

## Checklist

- [x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x] The name of the resource is spelled correctly (if applicable)
- [x] The link to the resource is working (if applicable)
- [x] The resource is added in the correct format (if applicable)
- [x] I have tested changes on my local computer (if applicable)
