### PR TITLE
Update border color for 'Get Started' button in dark mode

### DIFF
--- a/client/src/theme/theme_switch.css
+++ b/client/src/theme/theme_switch.css
@@ -52,3 +52,7 @@
     display: flex;
     align-items: center;
 }
+
+.dark-theme .get-started {
+    border-color: white;
+}


### PR DESCRIPTION
## Description
Changed the border color for dark mode for button Get Started.
<!-- Describe the changes made in the pull request -->

## Category

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding category -->

- [ ] Documentation
- [ ] Resource Addition
- [ ] Codebase
- [X] User Interface
- [ ] Feature Request

## Related Issue

<!-- Link the pull request to the corresponding issue by replacing 'XX' with the issue number -->
![Screenshot 2024-02-21 122649](https://github.com/Sriparno08/Openpedia/assets/142984776/cb10fed1-a9c0-4583-9838-2ebc6269b89f)

Fixes #344 

## Checklist

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding criteria -->

- [x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x] The name of the resource is spelled correctly (if applicable)
- [x] The link to the resource is working (if applicable)
- [x] The resource is added in the correct format (if applicable)
- [x] I have tested changes on my local computer (if applicable)
**Working under JWOC**