### PR TITLE
Chore: Fix SVG Link in 'Contributing to Open Source' Page

### DIFF
--- a/client/pages/contributing-to-open-source/index.html
+++ b/client/pages/contributing-to-open-source/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Openpedia</title>
-  <link rel="icon" href="./assets/short-logo.svg">
+  <link rel="icon" href="../../assets/short-logo.jpg">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="../../globals.css">
   <link rel="stylesheet" href="styles.css">


### PR DESCRIPTION
## Description

Updated icon path in "contributing to open source" page
## Category

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding category -->

- [ ] Documentation
- [ ] Resource Addition
- [x ] Codebase
- [ ] User Interface
- [ ] Feature Request

## Related Issue

<!-- Link the pull request to the corresponding issue by replacing 'XX' with the issue number -->

Fixes #393 

## Checklist

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding criteria -->

- [ x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [ x] The name of the resource is spelled correctly (if applicable)
- [ x] The link to the resource is working (if applicable)
- [ x] The resource is added in the correct format (if applicable)
- [ x] I have tested changes on my local computer (if applicable)
