### PR TITLE
updated the anker with a new Hyper-Reference

### DIFF
--- a/client/components/footer.js
+++ b/client/components/footer.js
@@ -27,7 +27,7 @@ footer.innerHTML = `<div class="contain">
                           <p><a href="./git/index.html" class="footer-links">Learn Git & GitHub</a></p>
                           <p><a href="./pages/contributing-to-open-source/index.html" class="footer-links">Contributing to Open Source</a></p>
                           <p><a href="./beginner-friendly-repo/index.html" class="footer-links">Beginner-Friendly Repos</a></p>
-                          <p><a href="./opensource_programs/index.html" class="footer-links">Open Source Programs</a></p>
+                          <p><a href="./pages/open-source-programs/index.html" class="footer-links">Open Source Programs</a></p>
                         </div>
                       </div>
 


### PR DESCRIPTION
old: ./opensource_programs/index.html
new: ./pages/open-source-programs/index.html

## Description
Chore: Fix 'Open Source Programs' Link in Landing Page Footer #386

We need to fix a broken link in the landing page footer that heads to the 'Open Source Programs' page.

Step 1: Go to client/components/footer.js
Step 2: Find the following link under <div class="col">...</div>

<a href="./opensource_programs/index.html" class="footer-links">Open Source Programs</a>
Step 3: Change it to

<a href="./pages/open-source-programs/index.html" class="footer-links">Open Source Programs</a>

Exactly what I fixed.

## Category

- [ ] Documentation
- [ ] Resource Addition
- [X] Codebase
- [ ] User Interface
- [ ] Feature Request

## Related Issue

Fixes #386 