### PR TITLE
Fixed LINK in categories section

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -41,7 +41,7 @@
 
         <div class="category">
           <h3 class="category-title">Contributing to Open Source</h3>
-          <a href="./Contributing to Opensource/index.html" class="category-link">More</a>
+          <a href="./pages/contributing-to-open-source/index.html" class="category-link">More</a>
         </div>
 
         <div class="category">


### PR DESCRIPTION
## Description

We need to fix a broken link in the 'Categories' section of the landing page that heads to the 'Contributing to Open Source' page.

## Category

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding category -->

- [ ] Documentation
- [ ] Resource Addition
- [x ] Codebase
- [ ] User Interface
- [ ] Feature Request

## Related Issue

#380 

Fixes #380 

## Checklist

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding criteria -->

- [ x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x ] The name of the resource is spelled correctly (if applicable)
- [ x] The link to the resource is working (if applicable)
- [ x] The resource is added in the correct format (if applicable)
- [ x] I have tested changes on my local computer (if applicable)
