### PR TITLE
Chore: Fix 'Learn Git & GitHub' Link in Landing Page Footer

### DIFF
--- a/client/components/footer.js
+++ b/client/components/footer.js
@@ -24,7 +24,7 @@ footer.innerHTML = `<div class="contain">
                         <div class="col">
                           <h3 id="Solutions" style="font-size: 15px;">Categories</h3>
                           <p><a href="./pages/introduction-to-open-source/index.html" class="footer-links">Introduction to Open Source</a></p>
-                          <p><a href="./git/index.html" class="footer-links">Learn Git & GitHub</a></p>
+                          <p><a href="./pages/learn-git-and-github/index.html" class="footer-links">Learn Git & GitHub</a></p>
                           <p><a href="./pages/contributing-to-open-source/index.html" class="footer-links">Contributing to Open Source</a></p>
                           <p><a href="./beginner-friendly-repo/index.html" class="footer-links">Beginner-Friendly Repos</a></p>
                           <p><a href="./pages/open-source-programs/index.html" class="footer-links">Open Source Programs</a></p>


### PR DESCRIPTION
## Description

In the `client/components/footer.js` I fixed the link from 

```
<a href="./git/index.html" class="footer-links">Learn Git & GitHub</a>
```
to

```
<a href="./pages/learn-git-and-github/index.html" class="footer-links">Learn Git & GitHub</a>
```


## Category

- [ ] Documentation
- [ ] Resource Addition
- [x] Codebase
- [ ] User Interface
- [ ] Feature Request

## Related Issue

Fixes #383 

## Checklist


- [x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x] The name of the resource is spelled correctly (if applicable)
- [x] The link to the resource is working (if applicable)
- [x] The resource is added in the correct format (if applicable)
- [x] I have tested changes on my local computer (if applicable)
