### PR TITLE
Chore: Fix 'Introduction to Open Source' Link in 'Categories' Section

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -27,7 +27,7 @@
       <section class="categories">
         <div class="category">
           <h3 class="category-title">Introduction to Open Source</h3>
-          <a href="./Introduction-opensource/index.html" class="category-link">More</a>
+          <a href="./pages/introduction-to-open-source/index.html" class="category-link">More</a>
         </div>
 
         <div class="category">


### PR DESCRIPTION
## Description

I changed the broken link for 'Introduction to Open Source' in the category section to the correct link.

## Category

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding category -->

- [ ] Documentation
- [ ] Resource Addition
- [x] Codebase
- [ ] User Interface
- [ ] Feature Request

## Related Issue

Fixes #378

## Checklist

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding criteria -->

- [x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x] The name of the resource is spelled correctly (if applicable)
- [x] The link to the resource is working (if applicable)
- [x] The resource is added in the correct format (if applicable)
- [x] I have tested changes on my local computer (if applicable)
