### PR TITLE
Fixed 'Beginner-Friendly Repos' Link in Landing Page Footer

### DIFF
--- a/client/components/footer.js
+++ b/client/components/footer.js
@@ -26,7 +26,7 @@ footer.innerHTML = `<div class="contain">
                           <p><a href="./Introduction-opensource/index.html" class="footer-links">Introduction to Open Source</a></p>
                           <p><a href="./git/index.html" class="footer-links">Learn Git & GitHub</a></p>
                           <p><a href="./pages/contributing-to-open-source/index.html" class="footer-links">Contributing to Open Source</a></p>
-                          <p><a href="./beginner-friendly-repo/index.html" class="footer-links">Beginner-Friendly Repos</a></p>
+                          <a href="./pages/beginner-friendly-repos/index.html" class="footer-links">Beginner-Friendly Repos</a>
                           <p><a href="./opensource_programs/index.html" class="footer-links">Open Source Programs</a></p>
                         </div>
                       </div>


### PR DESCRIPTION
## Description

<!-- Describe the changes made in the pull request -->

I fixed 'Beginner-Friendly Repos' Link in Landing Page Footer

## Category

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding category -->

- [ ] Documentation
- [ ] Resource Addition
- [x] Codebase
- [ ] User Interface
- [ ] Feature Request

## Related Issue

<!-- Link the pull request to the corresponding issue by replacing 'XX' with the issue number -->

Fixes #385
