### PR TITLE
Improved 'More' button style in both Light and Dark Modes

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -116,6 +116,7 @@
   transition: all 0.3s;
   color: var(--txt);
   background-color: var(--bg);
+  border-radius: 8px;
 }
 
 .category .category-link:hover {
@@ -226,6 +227,11 @@
   transition: all 0.3s;
   color: var(--txt);
   background-color: var(--bg);
+}
+
+.dark-theme .category .category-link:hover {
+  background-color: white;
+  color: black;
 }
 
 .dark-theme .contribute .contribute-link {


### PR DESCRIPTION
## Description

Improved the style of 'More' button by adding it a border radius. In dark mode, I changed the 'More' button style to have dark background, and upon hovering on it, the background gets white. This dark mode change corresponds perfectly with how the styling of 'More' button works in Light mode as well.

## Category- [User Interface]

## Related Issue

Issue : CSS enhancement for 'MORE' buttons in the Categories section. #414

## Checklist

<!-- Type 'x' in the square brackets '[ ]' to check the corresponding criteria -->

- [x] I have gone through the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [ ] The name of the resource is spelled correctly (if applicable)
- [ ] The link to the resource is working (if applicable)
- [ ] The resource is added in the correct format (if applicable)
- [x] I have tested changes on my local computer (if applicable)
