### PR TITLE
hover effect in about page corrected

### DIFF
--- a/client/components/footer.js
+++ b/client/components/footer.js
@@ -15,7 +15,7 @@ footer.innerHTML = `<div class="contain">
                             </a>
                           </p>
 
-                          <a style="font-size: 14px; margin-top: 0.5rem;" href="#about">About</a></p>
+                          <p><a href="#about" class="footer-links">About</a></p>
                           <p style="font-size: 14px; margin-top: 0.5rem;">
                             <a href="./pages/frequently-asked-questions/index.html" class="hover-link">Frequently Asked Questions</a>
                           </p>


### PR DESCRIPTION
## Description

This pull request adds a hover effect to the 'About' link in the landing page footer. The link now uses the footer-links class, which has been styled to change color and underline on hover.

## Category

- [X ] User Interface

## Related Issue

<!-- Link the pull request to the corresponding issue by replacing 'XX' with the issue number -->

Fixes #421

## Checklist

- [X] I have followed the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [X] The name of the resource is spelled correctly (if applicable)
- [X] I have tested changes on my local computer (if applicable)

Screenshots

Changes:-

![Screenshot (1177)](https://github.com/user-attachments/assets/496634ec-ec2b-4a4e-bf3a-11adac6d4a77)

UI:-

![Screenshot (1176)](https://github.com/user-attachments/assets/f3c41842-b4c2-4e65-a603-62a792fe46c4)
