### PR TITLE
[UI] Fix dark mode on page beginner friendly repos

### DIFF
--- a/client/pages/beginner-friendly-repos/app.js
+++ b/client/pages/beginner-friendly-repos/app.js
@@ -7,7 +7,10 @@ function renderCards() {
     card.className = "card";
     card.innerHTML = `
         <h3>${repo.title}</h3>
-        <p>${repo.description} <a href="${repo.url}">Read More</a></p>
+        <p>${repo.description}</p>
+        <div class="button-container">
+         <button class="btn"><a href="${repo.url}" target="_blank">Read More<i class="bi bi-box-arrow-up-right"></i></a><img class="link-arrow" src="/assets/open-link-arrow.svg" /></button>
+        </div>
       `;
     container.appendChild(card);
   });
@@ -18,7 +21,10 @@ function renderCards() {
     card.className = "card";
     card.innerHTML = `
         <h3>${repo.title}</h3>
-        <p>${repo.description} <a href="${repo.url}">Read More</a></p>
+        <p>${repo.description}</p>
+        <div class="button-container">
+         <button class="btn"><a href="${repo.url}" target="_blank">Read More<i class="bi bi-box-arrow-up-right"></i></a><img class="link-arrow" src="/assets/open-link-arrow.svg" /></button>
+        </div>
       `;
     container.appendChild(card);
   });
@@ -29,7 +35,10 @@ function renderCards() {
     card.className = "card";
     card.innerHTML = `
         <h3>${repo.title}</h3>
-        <p>${repo.description} <a href="${repo.url}">Read More</a></p>
+        <p>${repo.description}</p>
+        <div class="button-container">
+         <button class="btn"><a href="${repo.url}" target="_blank">Read More<i class="bi bi-box-arrow-up-right"></i></a><img class="link-arrow" src="/assets/open-link-arrow.svg" /></button>
+        </div>
       `;
     container.appendChild(card);
   });
@@ -40,7 +49,10 @@ function renderCards() {
     card.className = "card";
     card.innerHTML = `
         <h3>${repo.title}</h3>
-        <p>${repo.description} <a href="${repo.url}">Read More</a></p>
+        <p>${repo.description}</p>
+        <div class="button-container">
+         <button class="btn"><a href="${repo.url}" target="_blank">Read More<i class="bi bi-box-arrow-up-right"></i></a><img class="link-arrow" src="/assets/open-link-arrow.svg" /></button>
+        </div>
       `;
     container.appendChild(card);
   });
@@ -51,7 +63,10 @@ function renderCards() {
     card.className = "card";
     card.innerHTML = `
         <h3>${repo.title}</h3>
-        <p>${repo.description} <a href="${repo.url}">Read More</a></p>
+        <p>${repo.description}</p>
+        <div class="button-container">
+         <button class="btn"><a href="${repo.url}" target="_blank">Read More<i class="bi bi-box-arrow-up-right"></i></a><img class="link-arrow" src="/assets/open-link-arrow.svg" /></button>
+        </div>
       `;
     container.appendChild(card);
   });

--- a/client/pages/beginner-friendly-repos/styles.css
+++ b/client/pages/beginner-friendly-repos/styles.css
@@ -27,7 +27,7 @@ h2 {
   color: #9d12a3;
   font-family: Arial, Helvetica, sans-serif;
   text-align: center;
-  margin-bottom: 20px;
+  margin: 20px;
 }
 .dark-theme h2{
   color: #aee31f ;
@@ -41,25 +41,53 @@ h2 {
 }
 
 .card {
-  background-color: rgb(137, 196, 255);
+  background-color: rgb(32, 43, 85);
   border-radius: 10px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   padding: 20px;
   margin-bottom: 20px;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
-.dark-theme-card{
-  background-color: rgb(25, 50, 84);
-  color: #ffffff;
-  border-radius: 10px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  padding: 20px;
+
+.card h3 {
+  margin-bottom: 10px;
+}
+
+.card p {
+  flex-grow: 1;
   margin-bottom: 20px;
 }
-.dark-theme-card a{
-  color: #ffffff;
+
+.button-container {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-top: auto;
 }
-.dark-theme-card a:hover{
-  color: #aee31f ;
+
+.btn {
+  background-color: #8B5CF6;
+  padding: 10px 20px;
+  border: 1px solid black;
+  border-radius: 10px;
+  text-align: center;
+  display: flex;
+}
+
+.link-arrow {
+  width: 1rem;
+}
+
+.btn a {
+  color: white;
+  text-decoration: none;
+}
+
+.bi {
+  color: white;
 }
 
 #arrow {


### PR DESCRIPTION
## Description

Fixed the colors of the cards to improve the readable in dark mode. In doing so, I adjusted the colors to match the style of the other pages. Also, I added buttons for "Read more" in the same style as on other pages.  

### Now   
Dark mode:  
![image](https://github.com/user-attachments/assets/4c988b34-31f1-42ef-b6f3-18248e2edaff)

Light mode:  
![image](https://github.com/user-attachments/assets/13d798b2-7b2c-4d2a-bf86-25498ad6f039)

### Before
Dark mode:  
![image](https://github.com/user-attachments/assets/3b64b1af-6111-44d4-a0a0-bc1183794765)

Light mode:  
![image](https://github.com/user-attachments/assets/29fcf9da-422f-4974-be4e-d6f89e1c830b)


## Category

- [ ] Resource Addition
- [ ] Documentation
- [ ] Codebase
- [x] User Interface
- [ ] Feature Addition

## Related Issue

Fixes #543 

## Checklist

- [x] I have followed the [CONTRIBUTING](https://github.com/Sriparno08/Start-Contributing/blob/main/CONTRIBUTING.md) guide
- [x] The name of the resource is spelled correctly (if applicable)
- [x] The link to the resource is working (if applicable)
- [x] The resource is added in the correct format (if applicable)
- [x] I have tested changes on my local computer (if applicable)